### PR TITLE
Add tables for option and parameter types to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -90,12 +90,12 @@ var bemHelper2 = new BEMHelper({
 Options can be shared throughout a project by using [withDefaults()](#withdefaults).
 
 #### Options
-| Name                | Type      | Required | Description                                         |
+| Name                | Type      | Default  | Description                                         |
 |---------------------|-----------|----------|-----------------------------------------------------|
-| `name`              | `string`  | Yes      | The name of the BEM block.                          |
-| `prefix`            | `string`  | No       | A prefix for the block name.                        |
-| `modifierDelimiter` | `string`  | No       | The separator between element name and modifier name.|
-| `outputIsString`    | `boolean` | No       | Whether to return an object or a plain string from the helper.|
+| `name`              | `string`  | Required | The name of the BEM block.                          |
+| `prefix`            | `string`  | `''`     | A prefix for the block name.                        |
+| `modifierDelimiter` | `string`  | `'--'`   | The separator between element name and modifier name.|
+| `outputIsString`    | `boolean` | `false`  | Whether to return an object or a plain string from the helper.|
 
 ### Using the helper
 When executed, the helper returns an object with a `className` property. When the helper is called without any arguments, its value will consist of the block name (prefixed if applicable)

--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,14 @@ var bemHelper2 = new BEMHelper({
 ```
 Options can be shared throughout a project by using [withDefaults()](#withdefaults).
 
+#### Options
+| Name                | Type      | Required | Description                                         |
+|---------------------|-----------|----------|-----------------------------------------------------|
+| `name`              | `string`  | Yes      | The name of the BEM block.                          |
+| `prefix`            | `string`  | No       | A prefix for the block name.                        |
+| `modifierDelimiter` | `string`  | No       | The separator between element name and modifier name.|
+| `outputIsString`    | `boolean` | No       | Whether to return an object or a plain string from the helper.|
+
 ### Using the helper
 When executed, the helper returns an object with a `className` property. When the helper is called without any arguments, its value will consist of the block name (prefixed if applicable)
 ```jsx

--- a/readme.md
+++ b/readme.md
@@ -118,6 +118,19 @@ module.exports = React.createClass({
 });
 ```
 
+#### Parameters
+| Name             | Type                                    | Default  | Description              |
+|------------------|-----------------------------------------|----------|--------------------------|
+| [`element`][3]   | `string`                                | `''`     | The name of the BEM element.|
+| [`modifiers`][4] | `string` or `string[]` or `object` (\*) | `''`     | A set of BEM modifiers.  |
+| [`extra`][5]     | `string` or `string[]` or `object` (\*) | `''`     | A set of plain, unprefixed classes. |
+
+[3]: #element
+[4]: #modifiers
+[5]: #extra-classes
+
+**(\*)** _Class sets are represented as space-separated string or array of space-separated strings or an object mapping space-separated strings to booleans or boolean-valued functions._
+
 #### Alternate Syntax
 The bemHelper supports up to three arguments: `element`, `modifiers`, and `extra` classes, although _an object containing any of these parameters is also supported:_
 

--- a/readme.md
+++ b/readme.md
@@ -90,12 +90,15 @@ var bemHelper2 = new BEMHelper({
 Options can be shared throughout a project by using [withDefaults()](#withdefaults).
 
 #### Options
-| Name                | Type      | Default  | Description                                         |
-|---------------------|-----------|----------|-----------------------------------------------------|
-| `name`              | `string`  | Required | The name of the BEM block.                          |
-| `prefix`            | `string`  | `''`     | A prefix for the block name.                        |
-| `modifierDelimiter` | `string`  | `'--'`   | The separator between element name and modifier name.|
-| `outputIsString`    | `boolean` | `false`  | Whether to return an object or a plain string from the helper.|
+| Name                     | Type      | Default  | Description                                    |
+|--------------------------|-----------|----------|------------------------------------------------|
+| `name`                   | `string`  | Required | The name of the BEM block.                     |
+| `prefix`                 | `string`  | `''`     | A prefix for the block name.                   |
+| [`modifierDelimiter`][1] | `string`  | `'--'`   | The separator between element name and modifier name.|
+| [`outputIsString`][2]    | `boolean` | `false`  | Whether to return an object or a plain string from the helper.|
+
+[1]: #modifier-delimiter--default-bem-naming-scheme
+[2]: #output-as-string
 
 ### Using the helper
 When executed, the helper returns an object with a `className` property. When the helper is called without any arguments, its value will consist of the block name (prefixed if applicable)


### PR DESCRIPTION
Hopefully this makes it easier to parse the different options and parameters at a glance without reading the descriptions.